### PR TITLE
Add types and DB schema for datasource plugin Uids

### DIFF
--- a/packages/repco-core/package.json
+++ b/packages/repco-core/package.json
@@ -18,7 +18,7 @@
     "dotenv": "^16.0.1",
     "multiformats": "^9.7.0",
     "repco-prisma": "*",
-    "undici": "^5.8.0"
+    "undici": "^5.10.0"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/packages/repco-core/src/datasources/cba.ts
+++ b/packages/repco-core/src/datasources/cba.ts
@@ -4,7 +4,7 @@ import {
 } from 'repco-prisma/dist/generated/repco/index.js'
 import { fetch } from 'undici'
 import { CbaPost, CbaSeries } from './cba/types.js'
-import { DataSource, DataSourceDefinition } from '../datasource.js'
+import { DataSource, DataSourceDefinition, DataSourcePlugin } from '../datasource.js'
 import { ContentGroupingVariant, EntityBatch, EntityForm } from '../entity.js'
 import { extractCursorAndMap, FetchOpts } from '../helpers/datamapping.js'
 import { HttpError } from '../helpers/error.js'
@@ -36,6 +36,18 @@ function parseUrn(urn: string) {
   }
 }
 
+export class CbaDataSourcePlugin implements DataSourcePlugin {
+  createInstance(config: any) {
+    return new CbaDataSource()
+  }
+  get definition() {
+    return {
+      uid: 'urn:repco:datasource:cba',
+      name: 'CBA',
+    }
+  }
+}
+
 export class CbaDataSource implements DataSource {
   endpoint: string
   constructor() {
@@ -46,6 +58,7 @@ export class CbaDataSource implements DataSource {
     return {
       name: 'Cultural Broacasting Archive',
       uid: 'repco:datasource:cba.media',
+      pluginUid: 'urn:repco:datasource:cba',
     }
   }
 

--- a/packages/repco-core/src/entity.ts
+++ b/packages/repco-core/src/entity.ts
@@ -5,10 +5,7 @@
  * Furthermore the EntityBatch has a cursor which is usually a timestamp of the last retrieval of the entity.
  */
 
-import {
-  EntityInput,
-  EntityOutput,
-} from 'repco-prisma/dist/generated/repco/index.js'
+import { repco } from 'repco-prisma'
 import {
   ContentGrouping,
   ContentGroupingVariant,
@@ -19,7 +16,7 @@ import {
 
 export type { ContentItem, MediaAsset, ContentGrouping, Revision }
 export { ContentGroupingVariant }
-export type AnyEntityContent = EntityOutput['content']
+export type AnyEntityContent = repco.EntityOutput['content']
 
 export type EntityBatch = {
   cursor: string
@@ -34,7 +31,7 @@ export type Entity = {
 
 export type EntityFormContent = Omit<AnyEntityContent, 'revisionId'>
 
-export type EntityForm = EntityInput & {
+export type EntityForm = repco.EntityInput & {
   revision?: RevisionForm
 }
 
@@ -44,4 +41,8 @@ export type RevisionForm = {
   datasource?: string
   created?: Date
   alternativeIds?: string[]
+}
+
+export type EntityRevision = repco.EntityOutput & {
+  revision: Omit<Revision, 'content'>
 }

--- a/packages/repco-core/src/ingest.ts
+++ b/packages/repco-core/src/ingest.ts
@@ -37,7 +37,7 @@ export class Ingester extends Worker<void> {
   async start(): Promise<void> {
     const savedDataSources = await this.state.prisma.dataSource.findMany()
     for (const model of savedDataSources) {
-      if (!this.state.dataSourcePluginRegistry.has(model.uid)) {
+      if (!model.pluginUid || !this.state.dataSourcePluginRegistry.has(model.pluginUid)) {
         console.error(
           `Skip init of data source ${model.uid}: Unknown plugin ${model.pluginUid}`,
         )

--- a/packages/repco-core/src/ingest.ts
+++ b/packages/repco-core/src/ingest.ts
@@ -1,0 +1,56 @@
+import { DataSource as DataSourceModel, PrismaClient } from "repco-prisma";
+import { DataSourceConstructor, DataSourcePluginRegistry, DataSources, ingestUpdatesFromDataSource } from "./datasource.js";
+import { Entity, EntityBatch, EntityRevision } from "./entity.js";
+
+// export type WorkerConstructor
+export enum WorkerStatus {
+  Running = 'running',
+  Stopped = 'stopped',
+}
+
+export type SharedState = {
+  prisma: PrismaClient,
+  dataSourcePluginRegistry: DataSourcePluginRegistry
+}
+
+export abstract class Worker<Conf = void> {
+  private config: Conf
+  constructor(config: Conf, protected state: SharedState) {
+    this.config = config
+  }
+  abstract start(): Promise<void>
+  // abstract status(): WorkerStatus
+  async stop(): Promise<void> {}
+}
+
+export abstract class Indexer<Conf = void> extends Worker<Conf> {
+  abstract onRevisions(revisions: EntityRevision[]): Promise<void>
+}
+
+export class Ingester extends Worker<void> {
+  public datasources: DataSources
+  constructor(config: void, state: SharedState) {
+    super(config, state)
+    this.datasources = new DataSources()
+  }
+
+  async start(): Promise<void> {
+    const savedDataSources = await this.state.prisma.dataSource.findMany()
+    for (const model of savedDataSources) {
+      if (!this.state.dataSourcePluginRegistry.has(model.uid)) {
+        console.error(
+          `Skip init of data source ${model.uid}: Unknown plugin ${model.pluginUid}`,
+        )
+      }
+      const ds = this.state.dataSourcePluginRegistry.createInstance(
+        model.uid,
+        model.config,
+      )
+      this.datasources.register(ds)
+    }
+
+    for (const ds of this.datasources.all()) {
+      ingestUpdatesFromDataSource(this.state.prisma, this.datasources, ds)
+    }
+  }
+}

--- a/packages/repco-core/test/datasource.ts
+++ b/packages/repco-core/test/datasource.ts
@@ -14,6 +14,7 @@ class TestDataSource extends BaseDataSource implements DataSource {
     return {
       name: 'TestDataSource',
       uid: 'urn:repco:datasource:test',
+      pluginUid: 'urn:repco:datasource:test'
     }
   }
 

--- a/packages/repco-prisma/prisma/migrations/20220831192606_datasource_plugin/migration.sql
+++ b/packages/repco-prisma/prisma/migrations/20220831192606_datasource_plugin/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "DataSource" ADD COLUMN     "config" JSONB,
+ADD COLUMN     "pluginUid" TEXT;

--- a/packages/repco-prisma/prisma/schema.prisma
+++ b/packages/repco-prisma/prisma/schema.prisma
@@ -24,6 +24,8 @@ enum ContentGroupingVariant {
 
 model DataSource {
   uid String @id @unique
+  pluginUid String
+  config Json?
   cursor String
 }
 

--- a/packages/repco-prisma/prisma/schema.prisma
+++ b/packages/repco-prisma/prisma/schema.prisma
@@ -24,7 +24,8 @@ enum ContentGroupingVariant {
 
 model DataSource {
   uid String @id @unique
-  pluginUid String
+  // TODO: Make required once we reset the schema.
+  pluginUid String?
   config Json?
   cursor String
 }


### PR DESCRIPTION
As @nemi-notrace already mentioned earlier (and he was right): We have to properly split between *Datasource types* and *Datasource instances*. Currently they're 1-to-1, which makes no sense as soon as things get a bit more generic. And even for CBA there are possibly (soon) multiple instances.

This PR adds the basics to support this.

I'll add more commits that make use of this. For now biggest TODO is naming. In this PR I adopted:
* Instance: DataSource
* Type/Plugin: DataSourcePlugin

Not sure about these though. Open to suggestions.