### PR TITLE
fix cli ingest

### DIFF
--- a/packages/repco-core/src/cli.ts
+++ b/packages/repco-core/src/cli.ts
@@ -47,7 +47,7 @@ async function main() {
         `Ingested ${
           countAndCursor[ds.definition.uid].count
         } new revisions. New cursor: ${
-          countAndCursor['repco:datasource:cba.media'].cursor
+          countAndCursor[ds.definition.uid].cursor
         }. Datasource ("${ds.definition.name}")`,
       )
     }

--- a/packages/repco-core/src/cli.ts
+++ b/packages/repco-core/src/cli.ts
@@ -40,8 +40,11 @@ async function main() {
         `Ingest updates from \`${ds.definition.uid}\` ("${ds.definition.name}")`,
       )
     }
-    const { count, cursor } = await ingestUpdatesFromDataSources(prisma, dsr)
-    console.log(`Ingested ${count} new revisions. New cursor: ${cursor}`)
+    const countAndCursor = await ingestUpdatesFromDataSources(prisma, dsr)
+
+    console.log(
+      `Ingested ${countAndCursor['repco:datasource:cba.media'].count} new revisions. New cursor: ${countAndCursor['repco:datasource:cba.media'].cursor}`,
+    )
   } else if (command === 'log-content-items') {
     await loadAndlogAllContentItems(prisma)
   } else if (command === 'log-revisions') {

--- a/packages/repco-core/src/cli.ts
+++ b/packages/repco-core/src/cli.ts
@@ -42,9 +42,15 @@ async function main() {
     }
     const countAndCursor = await ingestUpdatesFromDataSources(prisma, dsr)
 
-    console.log(
-      `Ingested ${countAndCursor['repco:datasource:cba.media'].count} new revisions. New cursor: ${countAndCursor['repco:datasource:cba.media'].cursor}`,
-    )
+    for (const ds of dsr.all()) {
+      console.log(
+        `Ingested ${
+          countAndCursor[ds.definition.uid].count
+        } new revisions. New cursor: ${
+          countAndCursor['repco:datasource:cba.media'].cursor
+        }. Datasource ("${ds.definition.name}")`,
+      )
+    }
   } else if (command === 'log-content-items') {
     await loadAndlogAllContentItems(prisma)
   } else if (command === 'log-revisions') {


### PR DESCRIPTION
when running `yarn cli ingest` the new revisions and the count are displayed as undefiend. It looks like the object is not unpacked properly. This should be fixed with this pr
