### PR TITLE
feat(core): Authenticate commits with UCANs

### DIFF
--- a/packages/repco-core/src/instance.ts
+++ b/packages/repco-core/src/instance.ts
@@ -1,0 +1,124 @@
+import * as ucans from '@ucans/ucans'
+import * as uint8arrays from 'uint8arrays'
+import type { Prisma } from 'repco-prisma'
+import { KeypairScope } from 'repco-prisma'
+import { ErrorCode, RepoError } from './repo.js'
+import { delegatePublishingCapability } from './repo/auth.js'
+import { createCID } from './repo/blockstore.js'
+
+const REPO_SCOPE = 'repco/repo'
+
+let INSTANCE_KEYPAIR: ucans.EdKeypair | null = null
+
+export async function getPublishingUcanForInstance(
+  prisma: Prisma.TransactionClient,
+  repoDid: string,
+) {
+  const instanceDid = await getInstanceDid(prisma)
+  const where = {
+    scope: REPO_SCOPE,
+    audience: instanceDid,
+    resource: repoDid,
+  }
+  const data = await prisma.ucans.findFirst({ where })
+  if (data) return data.token
+  else throw new Error('UCAN not found.')
+}
+
+export async function instanceSignPayload(
+  prisma: Prisma.TransactionClient,
+  payload: Uint8Array,
+) {
+  const keypair = await getInstanceKeypair(prisma)
+  return keypair.sign(payload)
+}
+
+export async function delegatePublishingCapabilityToInstance(
+  prisma: Prisma.TransactionClient,
+  repoKeypair: ucans.EdKeypair,
+) {
+  const instanceDid = await getInstanceDid(prisma)
+  const token = await delegatePublishingCapability(repoKeypair, instanceDid)
+  const tokenBytes = uint8arrays.fromString(token)
+  const cid = await createCID(tokenBytes)
+  const data = {
+    scope: REPO_SCOPE,
+    audience: instanceDid,
+    resource: repoKeypair.did(),
+    token,
+    cid: cid.toString(),
+  }
+  await prisma.ucans.create({
+    data,
+  })
+  return token
+}
+
+export async function getInstanceDid(prisma: Prisma.TransactionClient) {
+  const keypair = await getInstanceKeypair(prisma)
+  return keypair.did()
+}
+
+export async function getInstanceKeypair(prisma: Prisma.TransactionClient) {
+  if (!INSTANCE_KEYPAIR) {
+    const name = 'root'
+    const scope = KeypairScope.INSTANCE
+    let keypair
+    try {
+      keypair = await loadKeypair(prisma, { name, scope })
+    } catch (_err) {
+      keypair = await createKeypair(prisma, scope, name)
+    }
+    INSTANCE_KEYPAIR = keypair
+  }
+  return INSTANCE_KEYPAIR
+}
+
+export async function createRepoKeypair(prisma: Prisma.TransactionClient) {
+  const scope = KeypairScope.REPO
+  const keypair = await createKeypair(prisma, scope)
+  await delegatePublishingCapabilityToInstance(prisma, keypair)
+  return keypair
+}
+
+export async function createKeypair(
+  prisma: Prisma.TransactionClient,
+  scope: KeypairScope,
+  name?: string,
+) {
+  const keypair = await ucans.EdKeypair.create({ exportable: true })
+  const did = keypair.did()
+  const data = {
+    did,
+    secret: await keypair.export(),
+    scope,
+    name,
+  }
+  await prisma.keypair.create({
+    data,
+  })
+  return keypair
+}
+
+export async function loadKeypair(
+  prisma: Prisma.TransactionClient,
+  where: Prisma.KeypairWhereInput,
+) {
+  const keypairData = await prisma.keypair.findFirst({
+    where,
+    select: { secret: true, did: true },
+  })
+  let keypair
+  if (keypairData) {
+    keypair = ucans.EdKeypair.fromSecretKey(keypairData.secret)
+    if (keypair.did() !== keypairData.did) {
+      throw new RepoError(
+        ErrorCode.INVALID,
+        `Stored secret key for DID ${keypairData.did} is invalid.`,
+      )
+    }
+    return keypair
+  }
+  const name = where.did || where.name || 'unknown'
+  throw new Error(`Keypair \`${name}\` not found`)
+}

--- a/packages/repco-core/src/repo/auth.ts
+++ b/packages/repco-core/src/repo/auth.ts
@@ -1,9 +1,8 @@
 import * as ucans from '@ucans/ucans'
+import { RootIpld } from './types.js'
 
-export type Authority = {
-  did: string
-  keypair?: ucans.EdKeypair
-}
+const PUBLISH_ABILITY = { namespace: 'repco', segments: ['PUBLISH'] }
+const DEFAULT_LIFETIME = 3600 * 24 * 365 * 10 // 10 years
 
 export async function verifySignature(
   did: string,
@@ -13,6 +12,68 @@ export async function verifySignature(
   return ucans.defaults.verifySignature(did, payload, sig)
 }
 
+export async function verifyRoot(root: RootIpld, repoDid: string) {
+  await verifySignature(root.agent, root.commit.bytes, root.sig)
+  await verifyPublishingCapability(root.cap, root.agent, repoDid)
+}
+
+export async function delegatePublishingCapability(
+  repoKeypair: ucans.EdKeypair,
+  audience: string,
+) {
+  const ucan = await ucans.build({
+    audience,
+    issuer: repoKeypair, // signing key
+    lifetimeInSeconds: DEFAULT_LIFETIME,
+    capabilities: [
+      {
+        with: {
+          scheme: 'repco',
+          hierPart: `//repo/${repoKeypair.did()}`,
+        },
+        can: PUBLISH_ABILITY,
+      },
+    ],
+  })
+  const token = ucans.encode(ucan)
+  return token
+}
+
+export async function verifyPublishingCapability(
+  token: string,
+  audience: string,
+  repoDid: string,
+) {
+  const result = await ucans.verify(token, {
+    // to make sure we're the intended recipient of this UCAN
+    audience,
+    // A callback for figuring out whether a UCAN is known to be revoked
+    isRevoked: async (_ucan) => false, // as a stub. Should look up the UCAN CID in a DB.
+    // capabilities required for this invocation & which owner we expect for each capability
+    requiredCapabilities: [
+      {
+        capability: {
+          with: {
+            scheme: 'repco',
+            hierPart: `//repo/${repoDid}`,
+          },
+          can: PUBLISH_ABILITY,
+        },
+        rootIssuer: repoDid, // check against the root owner of the repo
+      },
+    ],
+  })
+
+  if (result.ok) {
+    // The UCAN authorized the user
+  } else {
+    // Unauthorized
+    throw new Error(
+      `UCAN verification failed: ${audience} does not hold publishing capability for repo ${repoDid}`,
+    )
+  }
+}
+
 // export async function createRepoRoot() {
 //   const keypair = await ucans.EdKeypair.create()
 
@@ -20,7 +81,7 @@ export async function verifySignature(
 
 // export async function signCommit(keypair: ucans.EdKeypair, repoDid: string, commitCid: CID) {
 //   const signature = await keypair.sign(commitCid.bytes)
-//   // const aud = `did:repco:${repoDid}`
+//   // const aud = `did: repco: ${ repoDid }`
 //   // const ucan = await ucans.build({
 //   //   audience: "did:key:zabcde...", // recipient DID
 //   //   issuer: keypair, // signing key

--- a/packages/repco-core/src/repo/blockstore.ts
+++ b/packages/repco-core/src/repo/blockstore.ts
@@ -7,6 +7,11 @@ import { Level } from 'level'
 import { CID } from 'multiformats/cid'
 import { Prisma } from 'repco-prisma'
 
+export async function createCID(value: Uint8Array): Promise<CID> {
+  const block = await Block.encode({ value, hasher, codec })
+  return block.cid
+}
+
 class CIDNotFoundError extends Error {
   constructor(public cid: CID) {
     super('CID not found: ' + cid.toString())
@@ -323,7 +328,7 @@ export class LevelIpldBlockStore
 
 const ISO_DATE_REGEX = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
 
-type IpldScalar = string | number | CID | Uint8Array | null
+type IpldScalar = string | number | CID | boolean | Uint8Array | null
 interface IpldRecord {
   [k: string]: IpldValue
 }

--- a/packages/repco-core/src/repo/types.ts
+++ b/packages/repco-core/src/repo/types.ts
@@ -1,7 +1,7 @@
 import * as common from 'repco-common/zod'
 import * as z from 'zod'
-import { repco, Revision } from 'repco-prisma'
 import { CID } from 'multiformats/cid.js'
+import { repco, Revision } from 'repco-prisma'
 
 export const commitIpld = z.object({
   kind: z.literal('commit'),
@@ -70,12 +70,16 @@ export const rootIpld = z.object({
   kind: z.literal('root'),
   sig: common.bytes,
   commit: common.cid,
+  cap: z.string(),
+  agent: z.string()
 })
 
 export type RootIpld = {
   kind: 'root'
   sig: Uint8Array
   commit: CID
+  cap: string
+  agent: string
 }
 
 export function revisionIpldToDb(
@@ -92,8 +96,8 @@ export function revisionIpldToDb(
 }
 
 export type CommitBundle = {
-  root: { cid: CID, body: RootIpld }
-  commit: { cid: CID, body: CommitIpld }
+  root: { cid: CID; body: RootIpld }
+  commit: { cid: CID; body: CommitIpld }
   revisions: {
     revision: RevisionIpld
     revisionCid: CID


### PR DESCRIPTION
Each node (instance) gets a static keypair. A repo also has a keypair. Commits are signed with the instance keypair. Each commit root includes a UCAN capability authorizing to publish to the repo.