### PR TITLE
Work loop for datasources, transaction queue in repo

### DIFF
--- a/packages/repco-cli/src/commands/ds.ts
+++ b/packages/repco-cli/src/commands/ds.ts
@@ -90,13 +90,20 @@ export const ingest = createCommand({
   arguments: [],
   options: {
     repo: { type: 'string', short: 'r', help: 'Repo name or DID' },
+    loop: { type: 'boolean', short: 'r', help: 'Keep running in a loop'}
   },
   async run(opts, _args) {
     const repo = await Repo.openWithDefaults(opts.repo)
     const ingester = new Ingester(plugins, repo)
-    await ingester.init()
-    const result = await ingester.work()
-    console.log('finished', result)
+    if (opts.loop) {
+      const queue = ingester.workLoop()
+      for await (const result of queue) {
+        console.log(result)
+      }
+    } else {
+      const result = await ingester.ingestAll()
+      console.log(result)
+    }
   },
 })
 

--- a/packages/repco-core/src/repo.ts
+++ b/packages/repco-core/src/repo.ts
@@ -51,11 +51,11 @@ import { createEntityId, createRevisionId } from './util/id.js'
 export * from './repo/types.js'
 
 export type SaveBatchOpts = {
-  commitEmpty: boolean,
+  commitEmpty: boolean
 }
 
 export const SAVE_BATCH_DEFAULTS = {
-  commitEmpty: false
+  commitEmpty: false,
 }
 
 export type RevisionWithoutCid = Omit<Revision, 'revisionCid'>
@@ -89,7 +89,7 @@ const REVISION_SELECT = {
   entityType: true,
   dateCreated: true,
   uid: true,
-  contentCid: true
+  contentCid: true,
 }
 
 function defaultBlockStore(
@@ -363,7 +363,11 @@ export class Repo {
     return importRepoFromCar(this, stream, onProgress)
   }
 
-  async saveBatch(_agentDid: string, inputs: unknown[], opts: Partial<SaveBatchOpts> = {}) {
+  async saveBatch(
+    _agentDid: string,
+    inputs: unknown[],
+    opts: Partial<SaveBatchOpts> = {},
+  ) {
     if (!this.writeable) throw new Error('Repo is not writeable')
     const fullOpts: SaveBatchOpts = { ...opts, ...SAVE_BATCH_DEFAULTS }
     // Parse and assign uids.
@@ -383,7 +387,10 @@ export class Repo {
     })
   }
 
-  private async saveBatchInner(entities: EntityInputWithHeaders[], opts: SaveBatchOpts) {
+  private async saveBatchInner(
+    entities: EntityInputWithHeaders[],
+    opts: SaveBatchOpts,
+  ) {
     if (!this.publishingCapability) throw new Error('Repo is not writable')
     const agentKeypair = await getInstanceKeypair(this.prisma)
     const parent = await this.getHeadMaybe()
@@ -492,7 +499,6 @@ export class Repo {
 
     setUid(entity, uid)
 
-
     return { ...entity, headers, prevContentCid }
   }
 
@@ -595,7 +601,7 @@ export class Repo {
 }
 
 export class IpldRepo {
-  constructor(public record: RepoRecord, public blockstore: IpldBlockStore) {}
+  constructor(public record: RepoRecord, public blockstore: IpldBlockStore) { }
   get did() {
     return this.record.did
   }
@@ -819,9 +825,10 @@ export class RelationFinder {
       }
 
       // try to fetch them from the datasources
-      const { fetched, notFound } = await this.repo.dsr.fetchEntities(this.repo, [
-        ...this.pendingUris,
-      ])
+      const { fetched, notFound } = await this.repo.dsr.fetchEntities(
+        this.repo,
+        [...this.pendingUris],
+      )
       notFound.forEach((uri) => {
         this.missingUris.add(uri)
         this.pendingUris.delete(uri)

--- a/packages/repco-core/src/util/id.ts
+++ b/packages/repco-core/src/util/id.ts
@@ -25,6 +25,10 @@ export function createSourceRecordId(timestamp?: Date | number): string {
   return 's' + MultiID.createTimeAndRandom(timestamp).toString()
 }
 
+export function createRandomId(timestamp?: Date | number): string {
+  return MultiID.createTimeAndRandom(timestamp).toString()
+}
+
 export enum IDFormats {
   TimeAndRandom = 'r',
   TimeAndHash = 'h',

--- a/packages/repco-core/src/util/registry.ts
+++ b/packages/repco-core/src/util/registry.ts
@@ -15,6 +15,10 @@ export class Registry<T extends PluginLike> {
     return [...this.inner.values()]
   }
 
+  ids(): string[] {
+    return this.all().map(x => x.definition.uid)
+  }
+
   has(uid: string): boolean {
     return !!this.inner.has(uid)
   }


### PR DESCRIPTION
This adds
* A simple work loop to ingest updates from datasources, implemented as an async iterator of promises
* Repo commits are in a mutex queue, so that they run sequentially
* Improvements to datasource setup
* Fixes for the RSS datasource